### PR TITLE
Deleting isRealSeconds Flag

### DIFF
--- a/Assets/Scenes/Script Implementation/TimerInUI.cs
+++ b/Assets/Scenes/Script Implementation/TimerInUI.cs
@@ -20,12 +20,14 @@ public class TimerInUI :MonoBehaviour {
 	}
 
 	public void StartCountDownAsync() {
-		Timer.CountdownAsync (timeToCount, false, PrintInTimer2);
+		Timer.CountdownAsync (timeToCount, PrintInTimer2); // This method doesn't allow time scaled counters
 	}
 
 	public void StartCountDownCoroutine() {
 		timer.Countdown (timeToCount, false, PrintInTimer3);
 	}
+
+
 
 	private void PrintInTimer1(float time) {
 		timer1.text = (Math.Truncate (time * 1000) / 1000).ToString ();

--- a/Assets/Scripts/Timer.cs
+++ b/Assets/Scripts/Timer.cs
@@ -27,11 +27,9 @@ public class Timer :MonoBehaviour {
 	/// Countdown based Async methods, this is not the best aproach but it works, this method only show seconds
 	/// </summary>
 	/// <param name="time">Number of seconds to countdown.</param>
-	/// <param name="isRealSeconds">This parameter indicates if the countdown is on a game-scaled time or in real time</param>
 	/// <param name="callback">Action called every second during the countdown, this action recibes a interger parameter that indicates the remaining time in the countdown</param>
 	public static async void CountdownAsync(
 		int time,
-		bool isRealSeconds,
 		Action<int> callbackBySecond = null
 	) {
 		int remainingTime = time;


### PR DESCRIPTION
Deleting the "isRealSeconds" flag in CountdownAsync cause the async method doesn't allow GameScale time